### PR TITLE
fixed re flags

### DIFF
--- a/pyap/parser.py
+++ b/pyap/parser.py
@@ -67,7 +67,7 @@ class AddressParser:
 
     def _parse_address(self, address_string):
         '''Parses address into parts'''
-        match = utils.match(self.rules, address_string, re.VERBOSE | re.U)
+        match = utils.match(self.rules, address_string, flags=re.VERBOSE | re.U)
         if match:
             match_as_dict = match.groupdict()
             match_as_dict.update({'country_id': self.country})
@@ -123,7 +123,7 @@ class AddressParser:
             '―': '-',
         }
         for find, replace in six.iteritems(conversion):
-            text = re.sub(find, replace, text, re.UNICODE)
+            text = re.sub(find, replace, text, flags=re.UNICODE)
         return text
 
     def _get_addresses(self, text):
@@ -133,7 +133,7 @@ class AddressParser:
         matches = utils.findall(
             self.rules,
             text,
-            re.VERBOSE | re.U)
+            flags=re.VERBOSE | re.U)
 
         if(matches):
             for match in matches:

--- a/pyap/utils.py
+++ b/pyap/utils.py
@@ -23,7 +23,7 @@ if six.PY2:
         return re.match(
             unicode(regex, 'utf-8'),
             string,
-            flags
+            flags=flags
         )
 
     def findall(regex, string, flags=0):
@@ -33,7 +33,7 @@ if six.PY2:
         return re.findall(
             unicode(regex, 'utf-8'),
             string,
-            flags
+            flags=flags
         )
 
     def unicode_str(string):
@@ -44,11 +44,11 @@ elif six.PY3:
 
     def match(regex, string, flags=0):
         '''Utility function for re.match '''
-        return re.match(regex, string, flags)
+        return re.match(regex, string, flags=flags)
 
     def findall(regex, string, flags=0):
         '''Utility function for re.findall '''
-        return re.findall(regex, string, flags)
+        return re.findall(regex, string, flags=flags)
 
     def unicode_str(string):
         '''Return Unicode string'''


### PR DESCRIPTION
There was a bug in _normalize_string.  It used to be:

text = re.sub(find, replace, text, re.UNICODE)

But the syntax for re.sub is:

re.sub(pattern, repl, string, count=0, flags=0)¶

So re.UNICODE was being entered as the count parameter rather than as a flag.  This was causing problems when testing on long strings containing many addresses with newlines in between.  It was only extracting the first 14 or so addresses.

I find it is best practice to enter flags as a keyword arguments when using regex, as it is easy to forget or mix up the exact syntaxes, so I entered all flags as kwargs.  
