### PR TITLE
Match word boundary around state abbreviation

### DIFF
--- a/pyap/source_US/data.py
+++ b/pyap/source_US/data.py
@@ -354,14 +354,14 @@ full_street = r"""
 # region1 is actually a "state"
 region1 = r"""
         (?P<region1>
-            (?:
+            \b(?:
                 # states abbreviations
                 AL|AK|AZ|AR|CA|CO|CT|DE|DC|FL|GA|HI|ID|IL|IN|IA|KS|KY|LA|ME|MD|MA|MI|
                 MN|MS|MO|MT|NE|NV|NH|NJ|NM|NY|NC|ND|OH|OK|OR|PA|RI|SC|SD|TN|TX|UT|VT|
                 VA|WA|WV|WI|WY|
                 # unincorporated & commonwealth territories
                 AS|GU|MP|PR|VI
-            )
+            )\b
             |
             (?:
                 # states full


### PR DESCRIPTION
Without the word boundary, multiple states might be matched in a capitalized string like: "WINKY" (Wisconsin, Indiana, Kentucky...)