### PR TITLE
Improve GB postcode regex

### DIFF
--- a/pyap/source_GB/data.py
+++ b/pyap/source_GB/data.py
@@ -353,32 +353,43 @@ city = r"""
 
 postal_code = r"""
         (?P<postal_code>
-            (?:
-                (?:[gG][iI][rR] {0,}0[aA]{2})|
+            # Girobank postcode
+            (?:[gG][iI][rR] {0,}0[aA]{2})|
+            (?:  # British Overseas Territories in usual format
                 (?:
-                    (?:
-                        [aA][sS][cC][nN]|
-                        [sS][tT][hH][lL]|
-                        [tT][dD][cC][uU]|
-                        [bB][bB][nN][dD]|
-                        [bB][iI][qQ][qQ]|
-                        [fF][iI][qQ][qQ]|
-                        [pP][cC][rR][nN]|
-                        [sS][iI][qQ][qQ]|
-                        [iT][kK][cC][aA]
-                    )
-                    \ {0,}1[zZ]{2}
-                )|
-                (?:
-                    (?:
-                        (?:[a-pr-uwyzA-PR-UWYZ][a-hk-yxA-HK-XY]?[0-9][0-9]?)|
-                        (?:
-                            (?:[a-pr-uwyzA-PR-UWYZ][0-9][a-hjkstuwA-HJKSTUW])|
-                            (?:[a-pr-uwyzA-PR-UWYZ][a-hk-yA-HK-Y][0-9][abehmnprv-yABEHMNPRV-Y])
-                        )
-                    )
-                    \ {0,}[0-9][abd-hjlnp-uw-zABD-HJLNP-UW-Z]{2}
+                    [aA][sS][cC][nN]|
+                    [sS][tT][hH][lL]|
+                    [tT][dD][cC][uU]|
+                    [bB][bB][nN][dD]|
+                    [bB][iI][qQ][qQ]|
+                    [fF][iI][qQ][qQ]|
+                    [pP][cC][rR][nN]|
+                    [sS][iI][qQ][qQ]|
+                    [iT][kK][cC][aA]
                 )
+                \ {0,}1[zZ]{2}
+            )|
+            (?:  # British Overseas Territories in zip-code format
+                (KY[0-9]|MSR|VG|AI)[ -]{0,}[0-9]{4}
+            )|
+            # (?:  # Bermuda including this causes too many false positives, so excluded for now
+            #     [a-zA-Z]{2}\ {0,}[0-9]{2}
+            # )|
+            (?:  # British Forces Post Office
+                [Bb][Ff][Pp][Oo]\ {0,}[0-9]{1,4}
+            )|
+            (?:  # Mainland British postcodes
+                (?:
+                    (?:[Ww][Cc][0-9][abehmnprvwxyABEHMNPRVWXY])|
+                    (?:[Ee][Cc][1-4][abehmnprvwxyABEHMNPRVWXY])|
+                    (?:[Nn][Ww]1[Ww])|
+                    (?:[Ss][Ee]1[Pp])|
+                    (?:[Ss][Ww]1[abehmnprvwxyABEHMNPRVWXY])|
+                    (?:[EeNnWw]1[a-hjkpstuwA-HJKPSTUW])|
+                    (?:[BbEeGgLlMmNnSsWw][0-9][0-9]?)|
+                    (?:[a-pr-uwyzA-PR-UWYZ][a-hk-yxA-HK-XY][0-9][0-9]?)
+                )
+                \ {0,}[0-9][abd-hjlnp-uw-zABD-HJLNP-UW-Z]{2}
             )
         )  # end postal_code
 """

--- a/test_parser_gb.py
+++ b/test_parser_gb.py
@@ -461,7 +461,7 @@ def test_country(input, expected):
     # positive assertions
     ("11-59 High Road, East Finchley London, N2 8AW", True),
     ("88 White parkway, Stanleyton, L2 3DB", True),
-    ("Studio 96D, Graham roads, Westtown, L1A 3GP, Great Britain", True),
+    ("Studio 96D, Graham roads, Westtown, L1 3GP, Great Britain", True),
     ("01 Brett mall, Lake Donna, W02 3JQ", True),
     ("Flat 05, Byrne shores, Howardshire, GL6 8EA, UK", True),
     ("12 Henry route, Clementsborough, W2 5DQ", True),

--- a/tox.ini
+++ b/tox.ini
@@ -7,10 +7,13 @@
 envlist = py27, py38
 
 [testenv]
-commands = py.test \
-			test_parser.py \
-			test_parser_ca.py \
-			test_parser_us.py \
-			test_parser_gb.py
+commands =
+    py.test \
+        test_parser.py \
+        test_parser_ca.py \
+        test_parser_us.py \
+        test_parser_gb.py
 deps =
     pytest
+    pandas
+    requests


### PR DESCRIPTION
Small MR to improve the number of matched GB postcodes, previously some in the format AA1A were not matched correctly. It is also a little more specific, so that it matches fewer things that are not real postcodes.

I've also added a test against a huge list of all GB postcodes, to ensure that none are missed as was the case before.