### PR TITLE
Make space after 'Floor N|Nth Floor' optional

### DIFF
--- a/pyap/source_CA/data.py
+++ b/pyap/source_CA/data.py
@@ -309,11 +309,11 @@ street_type = r"""
 floor = r"""
             (?P<floor>
                 (?:
-                \d+[A-Za-z]{0,2}\.?\ [Ff][Ll][Oo][Oo][Rr]\ 
+                \d+[A-Za-z]{0,2}\.?\ [Ff][Ll][Oo][Oo][Rr]\ ?
                 )
                 |
                 (?:
-                    [Ff][Ll][Oo][Oo][Rr]\ \d+[A-Za-z]{0,2}\ 
+                    [Ff][Ll][Oo][Oo][Rr]\ \d+[A-Za-z]{0,2}\ ?
                 )
             )
         """

--- a/pyap/source_GB/data.py
+++ b/pyap/source_GB/data.py
@@ -217,11 +217,11 @@ street_type = r"""
 floor = r"""
                     (?P<floor>
                         (?:
-                        \d+[A-Za-z]{0,2}\.?\ [Ff][Ll][Oo][Oo][Rr]\ 
+                        \d+[A-Za-z]{0,2}\.?\ [Ff][Ll][Oo][Oo][Rr]\ ?
                         )
                         |
                         (?:
-                            [Ff][Ll][Oo][Oo][Rr]\ \d+[A-Za-z]{0,2}\ 
+                            [Ff][Ll][Oo][Oo][Rr]\ \d+[A-Za-z]{0,2}\ ?
                         )
                     )  # end floor
 """

--- a/pyap/source_US/data.py
+++ b/pyap/source_US/data.py
@@ -257,11 +257,11 @@ street_type = r"""
 floor = r"""
             (?P<floor>
                 (?:
-                \d+[A-Za-z]{0,2}\.?\ [Ff][Ll][Oo][Oo][Rr]\ 
+                \d+[A-Za-z]{0,2}\.?\ [Ff][Ll][Oo][Oo][Rr]\ ?
                 )
                 |
                 (?:
-                    [Ff][Ll][Oo][Oo][Rr]\ \d+[A-Za-z]{0,2}\ 
+                    [Ff][Ll][Oo][Oo][Rr]\ \d+[A-Za-z]{0,2}\ ?
                 )
             )
         """

--- a/test_parser_ca.py
+++ b/test_parser_ca.py
@@ -387,6 +387,8 @@ still finding correct matches in full_address
     ("3351, boul. des Forges C.P. 500, Trois-Rivières (Québec)"
         " Canada, G9A 5H7", True),
     ("3264 Mainway Burlington L7M 1A7 Ontario, Canada", True),
+    ("20 Fleeceline Road, Floor 3, Toronto, Ontario M8V 2K3", True),
+    ("20 Fleeceline Road, 3rd Floor, Toronto, Ontario M8V 2K3", True),
 ])
 def test_full_address_positive(input, expected):
     ''' tests exact string match for a full address '''

--- a/test_parser_gb.py
+++ b/test_parser_gb.py
@@ -447,6 +447,8 @@ def test_country(input, expected):
     ("No. 22 The Light, The Headrow, Leeds LS1 8TL", True),
     ("55 Glenfada Park, Londonderry BT48 9DR", True),
     ("Studio 53, Harrison cove, Smithbury, G88 4US", True),
+    ("Floor 4, 32 London Bridge St, London SE1 9SG", True),
+    ("4th Floor, 32 London Bridge St, London SE1 9SG", True),
     # negative assertions
     ("85 STEEL REGULAR SHAFT - NE", False),
     ("3 STRUCTURE WITH PE", False),

--- a/test_parser_us.py
+++ b/test_parser_us.py
@@ -412,6 +412,8 @@ def test_full_street_positive(input, expected):
     ("1500 Westlake Avenue North Suite 108 Seattle, WA 98109", True),
     ("840 Garrison Brooks Suite 985, New Sarah, OH 38255", True),
     ("840 Garrison Brooks Suite 985 New Sarah, OH 38255", True),
+    ("5545 Langston Blvd, Floor 2, Arlington, VA 22207", True),
+    ("5545 Langston Blvd., 2nd Floor, Arlington, VA 22207", True),
     # negative assertions
     ("85 STEEL REGULAR SHAFT - NE", False),
     ("3 STRUCTURE WITH PE", False),


### PR DESCRIPTION
# Overview
The "floor" regular expression in all three regex data modules was specified such that a space trailing the floor component of an address string was mandatory. This means that an address like:

```
pyap.parse("1234 Book St., 5th Floor, Simbagrad, NM 99999", country="US")
```
would fail to parse; however, the following would succeed:
```
pyap.parse("1234 Book St., 5th Floor , Simbagrad, NM 99999", country="US")
```

I suspect the trailing space was there in analogy with the occupancy regular expression where there are trailing spaces after Suite/Apartment/Room. The trailing space there is actually mandatory, since it separates the occupancy type from the number. 

In the case of floor, the number is part of the floor expression, so the space is optional and arguably superfluous, though spaces between floor number and a comma afterward may crop up from time-to-time and wouldn't necessarily inhibit something from being an address. 

# Changes
* Added optional flag to trailing spaces in floor expressions.
* Added positive examples to tests. 